### PR TITLE
fixes(auth) fix gg login is always ban issue

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -15,12 +15,12 @@ exports.getAllUsers = async (req, res) => {
 
 exports.banUser = async (req, res) => {
   await User.findByIdAndUpdate(req.params.userId, { isBanned: true });
-  res.redirect('/admin/manage-users');
+  res.redirect('/admin/users');
 };
 
 exports.unbanUser = async (req, res) => {
   await User.findByIdAndUpdate(req.params.userId, { isBanned: false });
-  res.redirect('/admin/manage-users');
+  res.redirect('/admin/users');
 };
 
 exports.postUserManager = async(req,res)=>{

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -135,7 +135,7 @@ exports.googleLogin = async (req, res) => {
 
       await existingUser.save();
     }
-    if (existingUser.isBanned === false){
+    if (existingUser.isBanned === true){
             return res.render('login', { error: 'Your account is banned! Please contact admin for more information' });
           }
     // Generate token for the user found or created

--- a/src/controllers/availabilityController.js
+++ b/src/controllers/availabilityController.js
@@ -150,7 +150,7 @@ exports.postAvailability = async (req, res) => {
       symptoms
     });
 
-    res.redirect('/vailability?success=1');
+    res.redirect('/availability?success=1');
   } catch (err) {
     console.error(err);
     const slots = await Availability.find({}).lean();


### PR DESCRIPTION
## Summary by Sourcery

Fix user management redirects and correct ban logic in Google login

Bug Fixes:
- Update ban and unban user redirects to point to "/admin/users" instead of "/admin/manage-users"
- Fix Google login to block only users with isBanned set to true